### PR TITLE
Fixes to historical figure curse filtering.

### DIFF
--- a/LegendsViewer/Controls/SimpleLists.cs
+++ b/LegendsViewer/Controls/SimpleLists.cs
@@ -21,8 +21,8 @@ namespace LegendsViewer
                 if (caste != "All") filtered = filtered.Where(hf => hf.Caste == caste);
                 if (type != "All") filtered = filtered.Where(hf => hf.AssociatedType == type);
                 if (deity) filtered = filtered.Where(hf => hf.Deity);
-                if (vampire ) filtered = filtered.Where(hf => hf.ActiveInteractions.Contains("VAMPIRE"));
-                if (werebeast) filtered = filtered.Where(hf => hf.ActiveInteractions.Contains("WEREBEAST"));
+                if (vampire) filtered = filtered.Where(hf => hf.ActiveInteractions.Where(it => it.Contains("VAMPIRE")).Count() > 0);
+                if (werebeast) filtered = filtered.Where(hf => hf.ActiveInteractions.Where(it => it.Contains("WEREBEAST")).Count() > 0);
                 if (force) filtered = filtered.Where(hf => hf.Force);
                 if (ghost) filtered = filtered.Where(hf => hf.Ghost);
                 if (Leader) filtered = filtered.Where(hf => hf.Positions.Count > 0);

--- a/LegendsViewer/Legends/HistoricalFigure.cs
+++ b/LegendsViewer/Legends/HistoricalFigure.cs
@@ -308,8 +308,11 @@ namespace LegendsViewer.Legends
 
             hfraceString += Race.ToLower();
 
-            if (ActiveInteractions.Contains("VAMPIRE"))
-                return hfraceString += " vampire";
+            if (ActiveInteractions.Where(it => it.Contains("VAMPIRE")).Count() > 0)
+                return hfraceString + " vampire";
+            if (ActiveInteractions.Where(it => it.Contains("WEREBEAST")).Count() > 0)
+                return hfraceString + " werebeast";
+
             return hfraceString;
 
         }
@@ -320,8 +323,10 @@ namespace LegendsViewer.Legends
                 return Race.ToLower() + " deity";
             if (Race == "Night Creature" && PreviousRace != "")
                 return PreviousRace.ToLower() + " turned night creature";
-            if (ActiveInteractions.Contains("VAMPIRE"))
+            if (ActiveInteractions.Where(it => it.Contains("VAMPIRE")).Count() > 0)
                 return Race.ToLower() + " vampire";
+            if (ActiveInteractions.Where(it => it.Contains("WEREBEAST")).Count() > 0)
+                return Race.ToLower() + " werebeast";
             return Race.ToLower();
         }
     }


### PR DESCRIPTION
Curses (vampires, werebeasts) were being filtered by searching for exact matches to the curse name (E.G. "VAMPIRE"), however this did not match the curse strings in the active interactions. Filtering (and historical figure naming based on curses) was fixed by using a search through all active interactions for strings that contained the sub-string of the curse name.

This method for determining if a historical figure is cursed has the issue that it searches through all active interactions for the respective sub-strings, when really only an initial match is necessary. This performance hit however does not seem significant in comparison the simplicity of the solution.