### PR TITLE
Fixed a crash related to civilisations lost to the end of stream.

### DIFF
--- a/LegendsViewer/Legends/HistoryParser.cs
+++ b/LegendsViewer/Legends/HistoryParser.cs
@@ -63,6 +63,22 @@ namespace LegendsViewer.Legends
             return true;
         }
 
+        private void ReadEOSCiv()
+        {
+            string civName = CurrentLine.Substring(0, CurrentLine.IndexOf(","));
+            try
+            {
+                CurrentCiv = World.GetEntity(civName);
+            }
+            catch (Exception e)
+            {
+                Log.AppendLine(e.Message + ", Civ");
+            }
+            CurrentCiv.Race = Formatting.InitCaps(CurrentLine.Substring(CurrentLine.IndexOf(",") + 2, CurrentLine.Length - CurrentLine.IndexOf(",") - 2).ToLower());
+            foreach (Entity group in CurrentCiv.Groups) group.Race = CurrentCiv.Race;
+            CurrentCiv.IsCiv = true;
+        }
+
         private void ReadWorships()
         {
             if (CurrentLine.Contains("Worship List"))
@@ -166,7 +182,12 @@ namespace LegendsViewer.Legends
                 else
                     SkipToNextCiv();
             }
+
             History.Close();
+
+            if (CurrentLine != null && CivStart())
+                ReadEOSCiv();
+
             return Log.ToString();
         }
     }


### PR DESCRIPTION
If while parsing a history file, the file ends with the name of a civilisation, end of stream will trigger and the civilisation will never be parsed. This will later result in a crash when attempting to print the `WorldStatsPrinter`. I addressed this by checking if a remaining current line is left unparsed post closing the history file, and then testing and parsing it as a civilisation. This needed a new EoS oriented function to avoid calling `ReadLine` while handling the civ, however due to it being the last line does not require worship or leadership parsing.