### PR TITLE
Mod compatibility

### DIFF
--- a/LegendsViewer/Controls/Chart/ChartControl.cs
+++ b/LegendsViewer/Controls/Chart/ChartControl.cs
@@ -623,10 +623,10 @@ namespace LegendsViewer
                     }
 
 
-                    hfDeaths.Select(death => death.HistoricalFigure.Race).ToList().ForEach(death => deathRaces.Add(AppHelpers.MakePopulationPlural(death)));
+                    hfDeaths.Select(death => death.HistoricalFigure.Race).ToList().ForEach(death => deathRaces.Add(Formatting.MakePopulationPlural(death)));
                     foreach (Battle.Squad squad in squads)
                     {
-                        string plural = AppHelpers.MakePopulationPlural(squad.Race);
+                        string plural = Formatting.MakePopulationPlural(squad.Race);
                         for (int i = 0; i < squad.Deaths; i++) deathRaces.Add(plural);
                     }
                     deathRaces.GroupBy(race => race).Select(race => new { Type = race.Key, Count = race.Count() }).OrderByDescending(race => race.Count).ToList().ForEach(race => { series.First().Points.AddY(race.Count); series.First().Points.Last().LegendText = race.Type; });
@@ -670,12 +670,12 @@ namespace LegendsViewer
                         hfDeathsList = hfDeathsList.Concat(battles1.Where(battle => battle.Defender == entity || battle.Defender.Parent == entity).SelectMany(battle => battle.GetSubEvents().OfType<HFDied>().Where(death => battle.NotableDefenders.Contains(death.HistoricalFigure))).ToList()).ToList();
                         squadsList = battles1.Where(battle => battle.Attacker == entity || battle.Attacker.Parent == entity).SelectMany(battle => battle.AttackerSquads).ToList();
                         squadsList = squadsList.Concat(battles1.Where(battle => battle.Defender == entity || battle.Defender.Parent == entity).SelectMany(battle => battle.DefenderSquads).ToList()).ToList();
-                        hfDeathsList.Select(death => death.HistoricalFigure.Race).ToList().ForEach(death => deathRacesList.Add(AppHelpers.MakePopulationPlural(death)));
+                        hfDeathsList.Select(death => death.HistoricalFigure.Race).ToList().ForEach(death => deathRacesList.Add(Formatting.MakePopulationPlural(death)));
 
                         //squadsList.GroupBy(squad => squad.Race).Select(squad => new { Race = squad.Key, Count = squad.Sum(race => race.Deaths) });
                         foreach (Battle.Squad squad in squadsList)
                         {
-                            string plural = AppHelpers.MakePopulationPlural(squad.Race);
+                            string plural = Formatting.MakePopulationPlural(squad.Race);
                             for (int i = 0; i < squad.Deaths; i++) deathRacesList.Add(plural);
                         }
 
@@ -695,11 +695,11 @@ namespace LegendsViewer
                     break;
                 case ChartOption.OtherBattleRemaining:
                     Battle battle1 = (FocusObject as Battle);
-                    List<string> attackers = battle1.NotableAttackers.Select(hf => AppHelpers.MakePopulationPlural(hf.Race)).ToList();
-                    List<string> attackersKilled = battle1.NotableAttackers.Where(hf => battle1.GetSubEvents().OfType<HFDied>().Count(death => death.HistoricalFigure == hf) > 0).Select(hf => AppHelpers.MakePopulationPlural(hf.Race)).ToList();
+                    List<string> attackers = battle1.NotableAttackers.Select(hf => Formatting.MakePopulationPlural(hf.Race)).ToList();
+                    List<string> attackersKilled = battle1.NotableAttackers.Where(hf => battle1.GetSubEvents().OfType<HFDied>().Count(death => death.HistoricalFigure == hf) > 0).Select(hf => Formatting.MakePopulationPlural(hf.Race)).ToList();
                     foreach (Battle.Squad squad in battle1.AttackerSquads)
                     {
-                        string plural = AppHelpers.MakePopulationPlural(squad.Race);
+                        string plural = Formatting.MakePopulationPlural(squad.Race);
                         for (int i = 0; i < squad.Numbers; i++) attackers.Add(plural);
                         for (int i = 0; i < squad.Deaths; i++) attackersKilled.Add(plural);
                     }
@@ -727,11 +727,11 @@ namespace LegendsViewer
                     series.Last().Points.Last().Label = "";
                     series.Last().Points.Last().AxisLabel = "VS.";
 
-                    List<string> defenders = battle1.NotableDefenders.Select(hf => AppHelpers.MakePopulationPlural(hf.Race)).ToList();
-                    List<string> defendersKilled = battle1.NotableDefenders.Where(hf => battle1.GetSubEvents().OfType<HFDied>().Count(death => death.HistoricalFigure == hf) > 0).Select(hf => AppHelpers.MakePopulationPlural(hf.Race)).ToList();
+                    List<string> defenders = battle1.NotableDefenders.Select(hf => Formatting.MakePopulationPlural(hf.Race)).ToList();
+                    List<string> defendersKilled = battle1.NotableDefenders.Where(hf => battle1.GetSubEvents().OfType<HFDied>().Count(death => death.HistoricalFigure == hf) > 0).Select(hf => Formatting.MakePopulationPlural(hf.Race)).ToList();
                     foreach (Battle.Squad squad in battle1.DefenderSquads)
                     {
-                        string plural = AppHelpers.MakePopulationPlural(squad.Race);
+                        string plural = Formatting.MakePopulationPlural(squad.Race);
                         for (int i = 0; i < squad.Numbers; i++) defenders.Add(plural);
                         for (int i = 0; i < squad.Deaths; i++) defendersKilled.Add(plural);
                     }

--- a/LegendsViewer/Controls/HTML/BattlePrinter.cs
+++ b/LegendsViewer/Controls/HTML/BattlePrinter.cs
@@ -72,7 +72,7 @@ namespace LegendsViewer.Controls
 
             foreach (var squadRace in squadRaces)
             {
-                HTML.AppendLine("<li>" + squadRace.Numbers + " " + AppHelpers.MakePopulationPlural(squadRace.Race));
+                HTML.AppendLine("<li>" + squadRace.Numbers + " " + Formatting.MakePopulationPlural(squadRace.Race));
                 HTML.Append(", " + squadRace.Deaths + " Losses</br>");
             }
             foreach (HistoricalFigure attacker in Battle.NotableAttackers)
@@ -100,7 +100,7 @@ namespace LegendsViewer.Controls
 
             foreach (var squadRace in squadRaces)
             {
-                HTML.AppendLine("<li>" + squadRace.Numbers + " " + AppHelpers.MakePopulationPlural(squadRace.Race));
+                HTML.AppendLine("<li>" + squadRace.Numbers + " " + Formatting.MakePopulationPlural(squadRace.Race));
                 HTML.Append(", " + squadRace.Deaths + " Losses</br>");
             }
             foreach (HistoricalFigure defender in Battle.NotableDefenders)

--- a/LegendsViewer/Controls/HTML/WorldStatsPrinter.cs
+++ b/LegendsViewer/Controls/HTML/WorldStatsPrinter.cs
@@ -278,7 +278,7 @@ namespace LegendsViewer.Controls
                     deathCollections = deathCollections.OrderByDescending(collectionType => collectionType.Count);
                     HTML.AppendLine("<ul>");
                     foreach (var deathCollection in deathCollections)
-                        HTML.AppendLine("<li>" + AppHelpers.InitCaps(deathCollection.Type) + ": " + deathCollection.Count + "</li>");
+                        HTML.AppendLine("<li>" + Formatting.InitCaps(deathCollection.Type) + ": " + deathCollection.Count + "</li>");
                     HTML.AppendLine("<li>None: " + World.Events.OfType<HFDied>().Count(death => death.ParentCollection == null) + "</li>");
                     HTML.AppendLine("</ul>");
                     HTML.AppendLine("</ul>");
@@ -344,7 +344,7 @@ namespace LegendsViewer.Controls
             collectionTypes = collectionTypes.OrderByDescending(collection => collection.Count);
             foreach (var collectionType in collectionTypes)
             {
-                HTML.AppendLine("<h2>" + AppHelpers.InitCaps(collectionType.Type) + ": " + collectionType.Count + "</h2>");
+                HTML.AppendLine("<h2>" + Formatting.InitCaps(collectionType.Type) + ": " + collectionType.Count + "</h2>");
                 HTML.AppendLine("<ul>");
                 var subCollections = from subCollection in World.EventCollections.Where(collection => collection.Type == collectionType.Type).SelectMany(collection => collection.Collections)
                                      group subCollection by subCollection.Type into subCollectionType
@@ -355,7 +355,7 @@ namespace LegendsViewer.Controls
                     HTML.AppendLine("<li>Sub Collections");
                     HTML.AppendLine("<ul>");
                     foreach (var subCollection in subCollections)
-                        HTML.AppendLine("<li>" + AppHelpers.InitCaps(subCollection.Type) + ": " + subCollection.Count + "</li>");
+                        HTML.AppendLine("<li>" + Formatting.InitCaps(subCollection.Type) + ": " + subCollection.Count + "</li>");
                     HTML.AppendLine("</ul>");
                 }
 

--- a/LegendsViewer/Controls/appClasses.cs
+++ b/LegendsViewer/Controls/appClasses.cs
@@ -284,26 +284,6 @@ namespace LegendsViewer
             return enumerationValue.ToString();
 
         }
-
-        public static string InitCaps(string name, bool all = true)
-        {
-            if (name.Length == 0) return name;
-            name = name.Trim();
-            string[] parts = name.Split(new string[] { " " }, StringSplitOptions.None);
-            string capName = "";
-            if (all)
-                foreach (string part in parts)
-                {
-                    if (capName.Length > 0) capName += " ";
-                    if (((part != "the" && part != "of") || (capName.Length == 0)) && part.Length > 0)
-                        capName += part.ToUpper()[0] + part.Substring(1, part.Length - 1);
-                    else
-                        capName += part.ToLower();
-                }
-            return capName;
-
-        }
-      
     }
 }
  

--- a/LegendsViewer/Controls/appClasses.cs
+++ b/LegendsViewer/Controls/appClasses.cs
@@ -285,35 +285,6 @@ namespace LegendsViewer
 
         }
 
-
-        public static string MakePopulationPlural(string population)
-        {
-            string ending = "";
-
-            if (population.Contains(" of"))
-            {
-                ending = population.Substring(population.IndexOf(" of"), population.Length - population.IndexOf(" of"));
-                population = population.Substring(0, population.IndexOf(" of"));
-            }
-
-            if (population.EndsWith("Men") || population.EndsWith("men") || population == "Humans") return population + ending;
-            else if (population.EndsWith("s") && !population.EndsWith("ss")) return population + ending;
-
-            if (population == "Human") population = "Humans";
-            else if (population.EndsWith("Man")) population = population.Replace("Man", "Men");
-            else if (population.EndsWith("man") && !population.Contains("Human")) population = population.Replace("man", "men");
-            else if (population.EndsWith("Woman")) population = population.Replace("Woman", "Women");
-            else if (population.EndsWith("woman")) population = population.Replace("woman", "women");
-            else if (population.EndsWith("f")) population = population.Substring(0, population.Length - 1) + "ves";
-            else if (population.EndsWith("x") || population.EndsWith("ch") || population.EndsWith("sh") || population.EndsWith("s")) population += "es";
-            else if (population.EndsWith("y") && !population.EndsWith("ay") && !population.EndsWith("ey") && !population.EndsWith("iy") && !population.EndsWith("oy") && !population.EndsWith("uy")) population = population.Substring(0, population.Length - 1) + "ies";
-            else population += "s";
-
-            if (ending != "") population += ending;
-
-            return population;
-        }
-
         public static string InitCaps(string name, bool all = true)
         {
             if (name.Length == 0) return name;

--- a/LegendsViewer/Legends/Formatting.cs
+++ b/LegendsViewer/Legends/Formatting.cs
@@ -48,7 +48,7 @@ namespace LegendsViewer.Legends
             else if (population.EndsWith("f")) population = population.Substring(0, population.Length - 1) + "ves";
             else if (population.EndsWith("x") || population.EndsWith("ch") || population.EndsWith("sh") || population.EndsWith("s")) population += "es";
             else if (population.EndsWith("y") && !population.EndsWith("ay") && !population.EndsWith("ey") && !population.EndsWith("iy") && !population.EndsWith("oy") && !population.EndsWith("uy")) population = population.Substring(0, population.Length - 1) + "ies";
-            else population += "s";
+            else if (!population.EndsWith("i")) population += "s";
 
             if (ending != "") population += ending;
 

--- a/LegendsViewer/Legends/Formatting.cs
+++ b/LegendsViewer/Legends/Formatting.cs
@@ -55,7 +55,6 @@ namespace LegendsViewer.Legends
             return population;
         }
 
-
         public static string FormatRace(string race)
         {
             if (race.Contains("DEMON")) return "Demon";

--- a/LegendsViewer/Legends/Formatting.cs
+++ b/LegendsViewer/Legends/Formatting.cs
@@ -48,7 +48,7 @@ namespace LegendsViewer.Legends
             else if (population.EndsWith("f")) population = population.Substring(0, population.Length - 1) + "ves";
             else if (population.EndsWith("x") || population.EndsWith("ch") || population.EndsWith("sh") || population.EndsWith("s")) population += "es";
             else if (population.EndsWith("y") && !population.EndsWith("ay") && !population.EndsWith("ey") && !population.EndsWith("iy") && !population.EndsWith("oy") && !population.EndsWith("uy")) population = population.Substring(0, population.Length - 1) + "ies";
-            else if (!population.EndsWith("i")) population += "s";
+            else if (!population.EndsWith("i") && !population.EndsWith("le")) population += "s";
 
             if (ending != "") population += ending;
 


### PR DESCRIPTION
Some basic mod compatibility fixes around pluralisation. Also removed some redundant functions.

I think it would be nice to clean up the names of modded races, E.G. "dl92creature nevrean" should just be "nevrean". But I can only think of three solutions: Loading raws to get the printable names, writing a dictionary that would have to be updated as mods change, or writing a function to try and remove suffixes and prefixes. Out of those loading raws seems like the best option, but that's still not exactly ideal as users would have to supply more files.

For now I'm going to work on the open issues on Parker147's branch.