### PR TITLE
workaround for issue 69 sets to unknown

### DIFF
--- a/LegendsViewer/Legends/Events/EntityOverthrown.cs
+++ b/LegendsViewer/Legends/Events/EntityOverthrown.cs
@@ -54,7 +54,15 @@ namespace LegendsViewer.Legends.Events
             string eventString = GetYearTime();
             eventString += Instigator.ToLink(link, pov, this);
             eventString += " toppled the government of ";
-            eventString += OverthrownHistoricalFigure.ToLink(link, pov, this);
+            try
+            {
+                eventString += OverthrownHistoricalFigure.ToLink(link, pov, this);
+            }
+            catch
+            {
+                OverthrownHistoricalFigure = new HistoricalFigure();
+                eventString += OverthrownHistoricalFigure.ToLink(link, pov, this);
+            }
             eventString += " of ";
             eventString += Entity.ToLink(link, pov, this);
             if (PositionTaker != Instigator)


### PR DESCRIPTION
Workaround for issue #69 not a full fix as does not can the correct overthrow status however does allow for the legends file item referenced in the issue to be loaded.

If this is not suitable please feel free to cancel. 